### PR TITLE
Add frontend test coverage [Resolves #38]

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ To upgrade npm:
 
 New components can be added in the `frontend/components` directory. There is a directory for each component, because soon (not yet) we will start bundling styles in individual component directories. Other components will be able to import your new component right away, but if you would like the component to made available *globally* (in other words, a Flask template), you will have to add this to `frontend/index.js`
 
+### Running front-end tests
+Jest is used for front-end tests. There are two convenience npm commands available for running tests:
+
+- `npm run test` to run the test suite once
+- `npm run test:watch` to run jest in watch mode, which will re-run tests upon file save
+
+Tests are located in `frontend/__tests__`. For tests that encompass web service calls, add the mocked output in `endpoint_examples`, and use it similarly to `actions.js#syncRoleAction`, so the JSON interface can remain in sync with the Flask server's expectations.
+
 ### Installing new modules
 In the `frontend` directory, install the package you want with `npm install --save <pkg-name>`. The --save option will persist this change to package.json.
 

--- a/endpoint_examples/hmis_only/jurisdictional_roles.json
+++ b/endpoint_examples/hmis_only/jurisdictional_roles.json
@@ -1,0 +1,6 @@
+{"results": [{
+	"jurisdictionSlug": "your_county",
+	"jurisdiction": "Your County",
+	"serviceProviderSlug": "hmis",
+	"serviceProvider": "HMIS"
+}]}

--- a/frontend/__tests__/actions.js
+++ b/frontend/__tests__/actions.js
@@ -1,0 +1,48 @@
+import * as actions from '../actions'
+import * as constants from '../constants'
+import configureMockStore from 'redux-mock-store'
+import fetchMock from 'fetch-mock'
+import thunk from 'redux-thunk'
+import fs from 'fs'
+
+
+describe('actions', () => {
+  it('should create an action to select a service provider', () => {
+    const payload = 'hmis'
+    const expectedAction = {
+      type: constants.SELECT_SERVICE_PROVIDER,
+      payload
+    }
+    expect(actions.selectServiceProvider(payload)).toEqual(expectedAction)
+  })
+})
+
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+function endpointJSON(user, endpoint) {
+  var fname = '../endpoint_examples/' + user + '/' + endpoint
+  return JSON.parse(fs.readFileSync(fname))
+}
+
+describe('syncRoleAction', () => {
+  it('should create actions to fetch and save available roles from the server', () => {
+    const mockReturnJSON = endpointJSON('hmis_only', 'jurisdictional_roles.json')
+    fetchMock.getOnce(
+      'jurisdictional_roles.json',
+      {
+        body: mockReturnJSON,
+        headers: { 'content-type': 'application/json' }
+      }
+    )
+    const expectedActions = [
+      { type: constants.SAVE_AVAILABLE_ROLES, payload: mockReturnJSON.results },
+      { type: constants.SELECT_JURISDICTION, payload: { slug: 'your_county', name: 'Your County' } }
+    ]
+    const store = mockStore({availableRoles: []})
+    return store.dispatch(actions.syncAvailableRoles()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions)
+    })
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node_modules/.bin/jest",
+    "test:watch": "node_modules/.bin/jest --watch",
     "start": "node_modules/.bin/webpack --progress --colors --watch",
     "build": "node_modules/.bin/webpack --progress --colors"
   },


### PR DESCRIPTION
- Add fetch-mock and redux-mock-store to enable the running frontend tests that interact with a fake redux store and fake Flask API
- Add endpoint_examples to put JSON endpoint response examples, with the goal of having both frontend and backend tests using it to ensure that the interface remains in sync
- Add __tests__ module and an actions.js file with a couple of example tests relating to action creators
- Add notes about frontend testing to README