### PR TITLE
Acceptance Testing [Resolves #132]

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Integrating HMIS and criminal-justice data
 3. `cp example_flask_config.yaml flask_config.yaml` and modify to match your tastes (in production, change the SECRET and SECURITY_PASSWORD_SALT!)
 4. `cp example_config.yaml config.yaml` and modify to match the resources (for instance, s3 buckets) available to you.
 5. `alembic upgrade head` to upgrade the Postgres database
-6. Install NodeJS (https://nodejs.org/en/)
-7. `cd frontend && npm install` to install dependencies (the initial install will take a few minutes, go have a snack!)
+6. `sh scripts/create_test_users.sh` to create some test app users
+7. Install NodeJS (https://nodejs.org/en/)
+8. `cd frontend && npm install` to install dependencies (the initial install will take a few minutes, go have a snack!)
 
 ## Run the app
 1. `cd frontend && npm run start` to watch JS files and recompile
@@ -52,6 +53,9 @@ conn.create_bucket('your-bucket')
 ## User Management
 The Flask-Security library is utilized, and it comes with CLI scripts for user and role management. 
 
+### Example Users
+Basic test users can be added by running [scripts/create_test_users.sh](scripts/create_test_users.sh) from the repository root directory with your virtual environment activated. This will allow basic usage of the app without manually creating any users or roles. However, instructions for such manual operations are below if you would like to add more users or event types.
+
 ### Adding Users
 Adding a user to the database:
 
@@ -82,11 +86,26 @@ The following will remove the user we created above from the role we created abo
 
 
 ## Running All Tests
-This project uses [Tox](https://tox.readthedocs.io/en/latest/) to run both the Python and JS test suites. This is recommended before pushing commits. To run all tests,
+This project uses [Tox](https://tox.readthedocs.io/en/latest/) to run both the Python and JS test suites. This is recommended before pushing commits. To run all tests (besides acceptance tests, due to the extra setup steps needed),
 
 1. Install tox: `pip install tox`
 
 2. Run tox in the repository root: `tox`
+
+## Acceptance Testing
+
+This repository has acceptance tests written using Nightwatch, which comes bundled in our JS developer dependencies so you don't need to install it separately. However, requires a locally running Selenium server and the Chrome driver. Later we will add other browsers to this setup.
+
+- [Download the Selenium standalone server](http://www.seleniumhq.org/download/)
+- [Download the ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads)
+
+To make the ChromeDriver executable work with our nightwatch config, it needs to be available in your PATH.
+
+The Selenium server is packaged as a JAR file, so you can run it as any other JAR file: `java -jar <path/to/selenium/jar/file>`
+
+The acceptance tests rely on some test users and jurisdictions in the webapp's database. This is covered in the setup at the top of this README, so make sure that is completed before trying to run these tests.
+
+You can run the tests with `npm run acceptance`. If all goes well, you should see many instances of Chrome pop up, a bunch of text entry, clicking and page loading, and all tests passing in your console.
 
 ## Dev Front-end Notes
 

--- a/scripts/create_test_users.sh
+++ b/scripts/create_test_users.sh
@@ -1,0 +1,13 @@
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask users create --password password -a testuser@example.com
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask roles create test_hmis_service_stays
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask roles create test_jail_bookings
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask roles add testuser@example.com test_hmis_service_stays
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask roles add testuser@example.com test_jail_bookings
+
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask users create --password password -a countyone@example.com
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask roles create countyone_hmis
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask roles add countyone@example.com countyone_hmis
+
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask users create --password password -a countytwo@example.com
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask roles create countytwo_hmis
+PYTHONPATH='./webapp' FLASK_APP=webapp/webapp/app.py flask roles add countytwo@example.com countytwo_hmis

--- a/webapp/frontend/components/header.js
+++ b/webapp/frontend/components/header.js
@@ -40,7 +40,7 @@ class Header extends React.Component {
           <Link to='/upload'><MenuItem primaryText='Upload' onTouchTap={this.handleToggle} /></Link>
           <Link to='/results'><MenuItem primaryText='Results' onTouchTap={this.handleToggle} /></Link>
           <Divider />
-          <Link to='/logout'><MenuItem value={'/logout'} primaryText='Logout' /></Link>
+          <Link to='/logout' target="_self"><MenuItem value={'/logout'} primaryText='Logout' /></Link>
         </Drawer>
       </div>
     )

--- a/webapp/frontend/nightwatch.json
+++ b/webapp/frontend/nightwatch.json
@@ -1,0 +1,48 @@
+
+{
+  "page_objects_path": ["selenium/page_objects"],
+  "src_folders" : ["selenium/flows"],
+  "output_folder" : "reports",
+  "test_workers": {
+    "enabled": true,
+    "workers": 2
+  },
+
+  "selenium" : {
+    "start_process" : false,
+    "server_path" : "",
+    "log_path" : "",
+    "host" : "127.0.0.1",
+    "port" : 4444,
+    "cli_args" : {
+      "webdriver.chrome.driver" : "",
+      "webdriver.ie.driver" : ""
+    }
+  },
+
+  "test_settings" : {
+    "default" : {
+      "launch_url" : "http://localhost:5000/",
+      "selenium_port"  : 4444,
+      "selenium_host"  : "localhost",
+      "silent": true,
+      "screenshots" : {
+        "enabled" : false,
+        "path" : ""
+      },
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true
+      }
+    },
+
+    "chrome" : {
+      "desiredCapabilities": {
+        "browserName": "google-chrome",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true
+      }
+    }
+  }
+}

--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -10,7 +10,8 @@
     "test": "node_modules/.bin/jest --coverage",
     "test:watch": "node_modules/.bin/jest --watch --coverage",
     "start": "node_modules/.bin/webpack --progress --colors --watch",
-    "build": "node_modules/.bin/webpack --progress --colors"
+    "build": "node_modules/.bin/webpack --progress --colors",
+	"acceptance": "node_modules/.bin/nightwatch"
   },
   "repository": {
     "type": "git",
@@ -66,6 +67,7 @@
     "image-webpack-loader": "^1.4.0",
     "jest": "^20.0.4",
     "manifest-revision-webpack-plugin": "^0.3",
+    "nightwatch": "^0.9.19",
     "node-sass": "^4.5.3",
     "postcss": "^6.0.8",
     "postcss-cssnext": "^2.9.0",

--- a/webapp/frontend/selenium/flows/auth-flow.js
+++ b/webapp/frontend/selenium/flows/auth-flow.js
@@ -1,0 +1,23 @@
+module.exports = {
+  'logging in': (client) => {
+    var login = client.page.login()
+    login
+      .navigate(client.launchUrl)
+      .standardLogin()
+      .getText('h1', function(comp) {
+        this.assert.equal(comp.value, 'Matching Tool - Test County')
+      })
+
+    login.assert.urlContains(client.launchUrl)
+  },
+  'logging out': (client) => {
+    var homepage = client.page.homepage()
+    homepage
+      .click('@homeDrawer')
+      .waitForElementVisible('@logoutButton', 1000)
+      .click('@logoutButton')
+      .waitForElementVisible('input[type=password]', 1000)
+
+    client.end()
+  },
+}

--- a/webapp/frontend/selenium/flows/countyone-login.js
+++ b/webapp/frontend/selenium/flows/countyone-login.js
@@ -1,0 +1,26 @@
+module.exports = {
+  'logging in': (client) => {
+    var login = client.page.login()
+    login
+      .navigate(client.launchUrl)
+      .waitForElementVisible('@userName', 1000)
+      .setValue('@userName', 'countyone@example.com')
+      .setValue('@password', 'password')
+      .click('@submit')
+      .getText('h1', function(comp) {
+        this.assert.equal(comp.value, 'Matching Tool - countyone')
+      })
+
+    login.assert.urlContains(client.launchUrl)
+  },
+  'loading the upload page': (client) => {
+    var homepage = client.page.homepage()
+    homepage
+      .click('@uploadLink')
+      .waitForElementVisible('h2', 1000)
+      .getText('h1', function(comp) {
+        this.assert.equal(comp.value, 'Matching Tool - countyone')
+      })
+    client.end()
+  },
+}

--- a/webapp/frontend/selenium/flows/countytwo-login.js
+++ b/webapp/frontend/selenium/flows/countytwo-login.js
@@ -1,0 +1,26 @@
+module.exports = {
+  'logging in': (client) => {
+    var login = client.page.login()
+    login
+      .navigate(client.launchUrl)
+      .waitForElementVisible('@userName', 1000)
+      .setValue('@userName', 'countytwo@example.com')
+      .setValue('@password', 'password')
+      .click('@submit')
+      .getText('h1', function(comp) {
+        this.assert.equal(comp.value, 'Matching Tool - countytwo')
+      })
+
+    login.assert.urlContains(client.launchUrl)
+  },
+  'loading the upload page': (client) => {
+    var homepage = client.page.homepage()
+    homepage
+      .click('@uploadLink')
+      .waitForElementVisible('h2', 1000)
+      .getText('h1', function(comp) {
+        this.assert.equal(comp.value, 'Matching Tool - countytwo')
+      })
+    client.end()
+  },
+}

--- a/webapp/frontend/selenium/flows/hmis-stays-upload-bad.js
+++ b/webapp/frontend/selenium/flows/hmis-stays-upload-bad.js
@@ -1,0 +1,23 @@
+module.exports = {
+  'logging in': (client) => {
+    var login = client.page.login()
+    login
+      .navigate(client.launchUrl)
+      .standardLogin()
+  },
+  'loading the upload page': (client) => {
+    var homepage = client.page.homepage()
+    homepage
+      .click('@uploadLink')
+      .waitForElementVisible('h2', 1000)
+  },
+  'pick bad HMIS stays file ': (client) => {
+    var upload = client.page.upload()
+    upload
+      .click('@hmisStays')
+      .waitForElementVisible('@browseForFile', 1000)
+      .uploadBadHMIS()
+      .waitForElementVisible('@tryAgainButton', 1000)
+    client.end()
+  },
+}

--- a/webapp/frontend/selenium/flows/hmis-stays-upload-good.js
+++ b/webapp/frontend/selenium/flows/hmis-stays-upload-good.js
@@ -1,0 +1,41 @@
+module.exports = {
+  'logging in': (client) => {
+    var login = client.page.login()
+    login
+      .navigate(client.launchUrl)
+      .standardLogin()
+  },
+  'loading the upload page': (client) => {
+    var homepage = client.page.homepage()
+    homepage
+      .getText('h2', function(comp) {
+        this.assert.equal(comp.value, 'Integrating HMIS and Criminal Justice Data')
+      })
+      .click('@uploadLink')
+      .waitForElementVisible('h2', 1000)
+      .getText('h2', function(comp) {
+        this.assert.equal(comp.value, 'Upload')
+      })
+    client.assert.urlContains('upload')
+  },
+  'pick good HMIS stays file': (client) => {
+    var upload = client.page.upload()
+    upload
+      .click('@hmisStays')
+      .waitForElementVisible('@browseForFile', 1000)
+      .uploadGoodHMIS()
+      .waitForElementVisible('@uploadConfirmButton', 1000)
+  },
+  'confirm upload': (client) => {
+    var upload = client.page.upload()
+    upload
+      .waitForElementVisible('@uploadConfirmButton', 1000)
+      .click('@uploadConfirmButton')
+      .waitForElementVisible('@backToHomeButton', 1000)
+      .click('@backToHomeButton')
+      .waitForElementNotPresent('@backToHomeButton', 1000)
+      
+    client.assert.urlEquals(client.launchUrl)
+    client.end()
+  }
+}

--- a/webapp/frontend/selenium/flows/jail-bookings-upload-good.js
+++ b/webapp/frontend/selenium/flows/jail-bookings-upload-good.js
@@ -1,0 +1,41 @@
+module.exports = {
+  'logging in': (client) => {
+    var login = client.page.login()
+    login
+      .navigate(client.launchUrl)
+      .standardLogin()
+  },
+  'loading the upload page': (client) => {
+    var homepage = client.page.homepage()
+    homepage
+      .getText('h2', function(comp) {
+        this.assert.equal(comp.value, 'Integrating HMIS and Criminal Justice Data')
+      })
+      .click('@uploadLink')
+      .waitForElementVisible('h2', 1000)
+      .getText('h2', function(comp) {
+        this.assert.equal(comp.value, 'Upload')
+      })
+    client.assert.urlContains('upload')
+  },
+  'pick good jail bookings file': (client) => {
+    var upload = client.page.upload()
+    upload
+      .click('@jailBookings')
+      .waitForElementVisible('@browseForFile', 1000)
+      .uploadGoodBookings()
+      .waitForElementVisible('@uploadConfirmButton', 1000)
+  },
+  'confirm upload': (client) => {
+    var upload = client.page.upload()
+    upload
+      .waitForElementVisible('@uploadConfirmButton', 1000)
+      .click('@uploadConfirmButton')
+      .waitForElementVisible('@backToHomeButton', 1000)
+      .click('@backToHomeButton')
+      .waitForElementNotPresent('@backToHomeButton', 1000)
+      
+    client.assert.urlEquals(client.launchUrl)
+    client.end()
+  }
+}

--- a/webapp/frontend/selenium/page_objects/homepage.js
+++ b/webapp/frontend/selenium/page_objects/homepage.js
@@ -1,0 +1,16 @@
+module.exports = {
+  elements: {
+    uploadLink: { 
+      selector: "//span[text()='Upload']",
+      locateStrategy: 'xpath'
+    },
+    homeDrawer: {
+      selector: "//div[@id='app']//button",
+      locateStrategy: 'xpath'
+    },
+    logoutButton: {
+      selector: "//div[text()='Logout']",
+      locateStrategy: 'xpath'
+    }
+  }
+};

--- a/webapp/frontend/selenium/page_objects/login.js
+++ b/webapp/frontend/selenium/page_objects/login.js
@@ -1,0 +1,25 @@
+var commands = {
+  login: function(user, pass) {
+    return this.waitForElementVisible('@userName', 1000)
+      .setValue('@userName', user)
+      .setValue('@password', pass)
+      .click('@submit')
+  },
+  standardLogin: function() {
+    return this.login('testuser@example.com', 'password')
+  }
+}
+module.exports = {
+  commands: [commands],
+  elements: {
+    userName: { 
+      selector: 'input[type=text]' 
+    },
+    password: {
+      selector: 'input[type=password]'
+    },
+    submit: {
+      selector: 'input[type=submit]'
+    }
+  }
+};

--- a/webapp/frontend/selenium/page_objects/upload.js
+++ b/webapp/frontend/selenium/page_objects/upload.js
@@ -1,0 +1,65 @@
+var uploadCommands = {
+  uploadGoodHMIS: function() {
+    return this
+      .setValue(
+        'input[type="file"]',
+        require('path').resolve(__dirname + '/../../../sample_data/uploader_input/hmis-fake-0.csv'),
+        function(result) { if(result.status != 0) { console.log(result) } }
+      )
+      .waitForElementVisible('@upload', 1000)
+      .click('@upload')
+  },
+  uploadBadHMIS: function() {
+    return this
+      .setValue(
+        'input[type="file"]',
+        require('path').resolve(__dirname + '/../../../sample_data/uploader_input/hmis-bad-0.csv'),
+        function(result) { if(result.status != 0) { console.log(result) } }
+      )
+      .waitForElementVisible('@upload', 1000)
+      .click('@upload')
+  },
+  uploadGoodBookings: function() {
+    return this
+      .setValue(
+        'input[type="file"]',
+        require('path').resolve(__dirname + '/../../../sample_data/uploader_input/bookings-fake-0.csv'),
+        function(result) { if(result.status != 0) { console.log(result) } }
+      )
+      .waitForElementVisible('@upload', 1000)
+      .click('@upload')
+  },
+}
+module.exports = {
+  commands: [uploadCommands],
+  elements: {
+    hmisStays: { 
+      selector: "//span[text()='HMIS Service Stays']",
+      locateStrategy: 'xpath'
+    },
+    jailBookings: { 
+      selector: "//span[text()='Jail Bookings']",
+      locateStrategy: 'xpath'
+    },
+    browseForFile: {
+      selector: "//span[text()='Browse for File']",
+      locateStrategy: 'xpath'
+    },
+    upload: {
+      selector: "//span[contains(text(), '.csv')]",
+      locateStrategy: 'xpath'
+    },
+    uploadConfirmButton: {
+      selector: "//button[contains(., 'Confirm Upload')]",
+      locateStrategy: 'xpath'
+    },
+    tryAgainButton: {
+      selector: "//span[text()='Try Again']",
+      locateStrategy: 'xpath'
+    },
+    backToHomeButton: {
+      selector: "//button[contains(., 'Back to Home')]",
+      locateStrategy: 'xpath'
+    }
+  }
+};

--- a/webapp/schemas/uploader/jail-bookings.json
+++ b/webapp/schemas/uploader/jail-bookings.json
@@ -254,7 +254,7 @@
             "format": "any"
         }
     ],
-    "trueValues": [ "true" ],
-    "falseValues": [ "false" ],
+    "trueValues": [ "Y", "true" ],
+    "falseValues": [ "N", "false" ],
 	"primaryKey": "internal_event_id"
 }


### PR DESCRIPTION
This commit adds acceptance testing to the uploader using nightwatch as a controller for a Selenium server. Basic flow tests are written for things like login, logout, successful and unsuccessful uploading attempts. Nightwatch has a feature called 'page objects' which is a way to reuse selectors and commands for a specific page. They are utilized heavily here.

There are also a couple of bugfixes here, illuminated by this testing.

Instructions for running these tests is in the README

- Add nightwatch package and config JSON file, using chrome for testing and two workers.
- Add login page object and flow test that covers login and logout
- Add homepage and upload page objects, and flow tests for HMIS stay and jail bookings upload
- Add simultaneous upload tests with separate counties, including a creation script for their users
- Fix jail bookings schema to no longer use booleans [Resolves #131]
- Fix logout link in header to bypass react-router and use the server [Resolves #130]
- Add instructions to README