### PR TITLE
Pass upload id to matcher [Resolves #175]

### DIFF
--- a/matcher/matcher/api.py
+++ b/matcher/matcher/api.py
@@ -84,6 +84,9 @@ def poke():
 
 @app.route('/match/<jurisdiction>/<event_type>', methods=['GET'])
 def match(jurisdiction, event_type):
+    upload_id = request.args.get('uploadId', None)
+    if not upload_id:
+        return jsonify(status='invalid', reason='uploadId not present')
     app.logger.debug("Someone wants to start a matching process!")
 
     indexer_func = getattr(indexer, INDEXER)

--- a/webapp/webapp/apis/upload.py
+++ b/webapp/webapp/apis/upload.py
@@ -232,7 +232,7 @@ def merge_file():
             merge_log = db_session.query(MergeLog).get(merge_id)
             try:
                 logging.info('Merge succeeded. Now querying matcher')
-                notify_matcher(upload_log.jurisdiction_slug, upload_log.event_type_slug)
+                notify_matcher(upload_log.jurisdiction_slug, upload_log.event_type_slug, upload_id)
             except Exception as e:
                 logging.error('Error matching: ', e)
                 return make_response(jsonify(status='error'), 500)

--- a/webapp/webapp/tests/test_endpoints.py
+++ b/webapp/webapp/tests/test_endpoints.py
@@ -91,7 +91,6 @@ class MergeFileTestCase(unittest.TestCase):
                     # present in s3 and metadata in the database
                     # use the upload file endpoint as a shortcut for setting
                     # this environment up quickly, though this is not ideal
-                    request_mock.get(re.compile('/match/boone/hmis_service_stays'), text='stuff')
                     response = app.post(
                         '/api/upload/upload_file?jurisdiction=boone&eventType=hmis_service_stays',
                         content_type='multipart/form-data',
@@ -104,6 +103,8 @@ class MergeFileTestCase(unittest.TestCase):
                     assert response_data['status'] == 'valid'
                     upload_id = json.loads(response.get_data().decode('utf-8'))['uploadId']
 
+                    compiled_regex = re.compile('/match/boone/hmis_service_stays\?uploadId={upload_id}'.format(upload_id=upload_id))
+                    request_mock.get(compiled_regex, text='stuff')
                     # okay, here's what we really want to test.
                     # call the merge endpoint
                     response = app.post('/api/upload/merge_file?uploadId={}'.format(upload_id))
@@ -117,4 +118,3 @@ class MergeFileTestCase(unittest.TestCase):
 
                     # and make sure that the merge log has a record of this
                     assert db_session.query(MergeLog).filter(MergeLog.upload_id == '123-456').one
-

--- a/webapp/webapp/utils.py
+++ b/webapp/webapp/utils.py
@@ -99,13 +99,14 @@ def generate_master_table_name(jurisdiction, event_type):
     return '{jurisdiction}_{event_type}_master'.format(**locals())
 
 
-def notify_matcher(jurisdiction, event_type):
+def notify_matcher(jurisdiction, event_type, upload_id):
     matcher_response = requests.get(
-        'http://{location}:{port}/match/{jurisdiction}/{event_type}'.format(
+        'http://{location}:{port}/match/{jurisdiction}/{event_type}?uploadId={upload_id}'.format(
             location=app_config['matcher_location'],
             port=app_config['matcher_port'],
             jurisdiction=jurisdiction,
-            event_type=event_type
+            event_type=event_type,
+            upload_id=upload_id
         )
     )
     if matcher_response.status_code != 200:


### PR DESCRIPTION
- Add upload id to uploader's payload to matcher
- Modify matcher API to expect an upload id