### PR TITLE
simplify keeping only relevant columns [Resolves #73]

### DIFF
--- a/matcher/matcher/ioutils.py
+++ b/matcher/matcher/ioutils.py
@@ -84,7 +84,7 @@ def load_one_event_type(jurisdiction:str, event_type:str, upload_id:str) -> pd.D
         df = read_merged_data_from_s3(jurisdiction, event_type)
 
         # Dropping columns that we don't need for matching
-        df = utils.select_columns(df=df, keys=KEYS)
+        df = df[KEYS]
 
         # Keeping track of the event_type
         df['event_type'] = event_type

--- a/matcher/matcher/utils.py
+++ b/matcher/matcher/utils.py
@@ -50,19 +50,6 @@ def join_matched_and_merged_data(right_df:pd.DataFrame, jurisdiction:str, event_
     return df
 
 
-def select_columns(df:pd.DataFrame, keys:list) -> pd.DataFrame:
-    """
-    Reduces the dataframe to the columns selected for matching.
-
-    We always expect at least two columns: source and source_id
-    """
-    logger.info(f'Selecting columns for matching.')
-    columns_to_select = ['source', 'source_id', 'internal_person_id', 'source_index']
-    if keys:
-        columns_to_select = columns_to_select + keys
-
-    return df.reindex(keys, axis="columns")
-
-
 def unique_match_id():
     return str(uuid4())
+


### PR DESCRIPTION
This removes the `select_columns` utility in favor of a single line solution. Since we are only keeping the keys + any metadata we create, we can do the column selection much more simply.