### PR TITLE
Refactor docker-compose-prod to use env files [Resolves #272]

### DIFF
--- a/_env
+++ b/_env
@@ -4,3 +4,16 @@ POSTGRES_PORT=5432
 POSTGRES_DB=csh
 POSTGRES_USER=csh
 POSTGRES_PASSWORD=csh
+
+# Flask configuration
+SECRET_KEY=dev
+SECURITY_PASSWORD_SALT=abcdefg
+
+# Mail configuration (optional, only needed for reset password functionality in webapp)
+MAIL_SERVER=""
+MAIL_PORT=625
+MAIL_USE_SSL=True
+MAIL_USE_TLS=False
+MAIL_USERNAME=""
+MAIL_PASSWORD=""
+MAIL_DEFAULT_SENDER=""

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -6,10 +6,9 @@ services:
         image: postgres:10
         ports:
             - 5444:5432
-        environment:
-            - POSTGRES_DB=${PGDATABASE}
-            - POSTGRES_USER=${PGUSER}
-            - POSTGRES_PASSWORD=${PGPASSWORD}
+        env_file:
+          - .env
+
     webapp:
         container_name: webapp
         build: ./webapp
@@ -19,33 +18,12 @@ services:
             - '.:/csh'
         ports:
             - 5000:5000
+        env_file:
+            - webapp.env
+            - .env
         environment:
-            # Flask
-            - SECRET_KEY
-            - DEBUG
-            - SECURITY_PASSWORD_SALT
-            # Mail
-            - MAIL_SERVER
-            - MAIL_PORT
-            - MAIL_USE_SSL
-            - MAIL_USE_TLS
-            - MAIL_USERNAME
-            - MAIL_PASSWORD
-            - MAIL_DEFAULT_SENDER
-            # S3 Configuration
-            - RAW_UPLOADS_PATH=s3://dsapp-criminal-justice/csh/matcher/{jurisdiction}/{event_type}/uploaded/{date}/{upload_id}
-            - MERGED_UPLOADS_PATH=s3://dsapp-criminal-justice/csh/matcher/{jurisdiction}/{event_type}/merged
-            - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-            - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-            # Database connection
-            - PGHOST=csh_db
-            - PGPORT=5432
-            - PGUSER
-            - PGDATABASE
-            - PGPASSWORD
-            # Matcher connection
-            - MATCHER_LOCATION=matcher
-            - MATCHER_PORT=5000
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
 
     matcher:
         container_name: matcher
@@ -54,28 +32,12 @@ services:
             - '.:/csh' # HOST:CONTAINER
         ports:
             - 5001:5000 # HOST:CONTAINER
+        env_file:
+            - matcher.env
+            - .env
         environment:
-            # File storage configuration
-            - S3_BUCKET=dsapp-criminal-justice
-            - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-            - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-            # Matcher distance calculation configuration
-            - INDEXER=identity
-            - KEYS=['first_name', 'middle_name', 'last_name', 'dob', 'ssn', 'dmv_number', 'dmv_state', 'race', 'ethnicity', 'sex']
-            - CONTRASTER=exact
-            - BLOCKING_RULES={'last_name':1, 'dob':3}
-            # Matcher clustering configuration
-            - EPS=0.2
-            - MIN_SAMPLES=1
-            - ALGORITHM=auto
-            - LEAF_SIZE=30
-            - N_JOBS=1
-            # Database connection configuration
-            - PGHOST=csh_db
-            - PGPORT=5432
-            - PGUSER
-            - PGDATABASE
-            - PGPASSWORD
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
 
     matcher_worker:
         image: csh_matcher
@@ -86,28 +48,13 @@ services:
         depends_on:
             - redis
             - matcher
+        env_file:
+            - matcher.env
+            - .env
         environment:
-            # File storage configuration
-            - S3_BUCKET=dsapp-criminal-justice
-            - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-            - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-            # Matcher distance calculation configuration
-            - INDEXER=identity
-            - KEYS=['first_name', 'middle_name', 'last_name', 'dob', 'ssn', 'dmv_number', 'dmv_state', 'race', 'ethnicity', 'sex']
-            - CONTRASTER=exact
-            # Matcher clustering configuration
-            - EPS=0.2
-            - MIN_SAMPLES=1
-            - ALGORITHM=auto
-            - LEAF_SIZE=30
-            - N_JOBS=1
-            - BLOCKING_RULES={'last_name':1, 'dob':3}
-            # Database connection configuration
-            - PGHOST=csh_db
-            - PGPORT=5432
-            - PGUSER
-            - PGDATABASE
-            - PGPASSWORD
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+
     webapp_worker:
         image: csh_webapp
         container_name: webapp_worker
@@ -117,37 +64,19 @@ services:
         depends_on:
             - redis
             - webapp
+        env_file:
+            - webapp.env
+            - .env
         environment:
-            # Flask
-            - SECRET_KEY
-            - DEBUG
-            - SECURITY_PASSWORD_SALT
-            # Mail
-            - MAIL_SERVER
-            - MAIL_PORT
-            - MAIL_USE_SSL
-            - MAIL_USE_TLS
-            - MAIL_USERNAME
-            - MAIL_PASSWORD
-            - MAIL_DEFAULT_SENDER
-            # S3 Configuration
-            - RAW_UPLOADS_PATH=s3://dsapp-criminal-justice/csh/matcher/{jurisdiction}/{event_type}/uploaded/{date}/{upload_id}
-            - MERGED_UPLOADS_PATH=s3://dsapp-criminal-justice/csh/matcher/{jurisdiction}/{event_type}/merged
-            - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-            - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-            # Database connection
-            - PGHOST=csh_db
-            - PGPORT=5432
-            - PGUSER
-            - PGDATABASE
-            - PGPASSWORD
-            # Matcher connection
-            - MATCHER_LOCATION=matcher
-            - MATCHER_PORT=5000
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+
     redis:
        image: redis
+       container_name: csh_queue
        ports:
          - 6379:6379
+
     nginx:
         image: "nginx:1.13.5"
         ports:


### PR DESCRIPTION
- Bring docker-compose-prod up to date with docker-compose, so now only difference is the existence of the nginx container
- Update _env file with placeholders for more environment variables, particularly those that should be set in production