### PR TITLE
Various uploader fixes

### DIFF
--- a/webapp/schemas/uploader/test.json
+++ b/webapp/schemas/uploader/test.json
@@ -2,35 +2,35 @@
 	"name": "Test",
     "fields": [
         {
-            "name": "Internal Person ID",
+            "name": "internal_person_id",
             "type": "string",
             "constraints": {
                 "required": true
             }
         },
         {
-            "name": "Internal Event ID",
+            "name": "internal_event_id",
             "type": "string",
             "constraints": {
                 "required": true
             }
         },
         {
-            "name": "Location ID",
+            "name": "location_id",
             "type": "string",
             "constraints": {
                 "required": true
             }
         },
         {
-            "name": "Full Name",
+            "name": "full_name",
             "type": "string",
             "constraints": {
                 "required": true
             }
         },
         {
-            "name": "Birthdate",
+            "name": "birthdate",
             "type": "date",
             "format": "any",
             "constraints": {
@@ -38,7 +38,7 @@
             }
         },
 		{
-			"name": "SSN",
+			"name": "ssn",
 			"type": "string",
 			"constraints": {
 				"required": true
@@ -47,5 +47,5 @@
     ],
     "trueValues": [ "true" ],
     "falseValues": [ "false" ],
-	"primaryKey": ["Internal Event ID", "Location ID"]
+	"primaryKey": ["internal_event_id", "location_id"]
 }

--- a/webapp/webapp/tests/test_endpoints.py
+++ b/webapp/webapp/tests/test_endpoints.py
@@ -153,7 +153,7 @@ class UploadFileTestCase(unittest.TestCase):
             response_data = json.loads(response.get_data().decode('utf-8'))
             assert 'validation' in response_data
             assert response_data['validation']['status'] == 'invalid'
-            assert 'duplicate primary key' in response_data['upload_result']['errorReport'][0]['message']
+            assert 'Duplicate key' in response_data['upload_result']['errorReport'][0]['message']
 
 
 class MergeFileTestCase(unittest.TestCase):


### PR DESCRIPTION
- Beef up the the async_validation function:
	- header validation (new!) [Resolves #196]
	- upload to s3 (necessary for next one)
	- copy raw table to db (desired to perform duplicate key check in the DB, but still as a validation)
	- sync upload metadata to DB (it should happen when the raw table is uploaded and copied)
- Modify copy raw table to db to include duplicate key check, and remove code-implemented duplicate key check from goodtables [Resolves #271] [Resolves #268]
- Check is_failed when getting validation results and log the error if so [Resolves #267]
- Change test column names (in test schema file and otherwise) to snake_case to match real schemas, this made working with them easier