### PR TITLE
Expunge script [Resolves #159]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Integrating HMIS and criminal-justice data
 		- `jail_booking_charges`
 	- Add your user to that role. Example using the user and role from above: `docker exec -it webapp flask roles add testuser@example.com cook_hmis_service_stays`
 
+## Expunging Data
+
+There is a data expunging script that is provided. It does *not* expunge individual records, but rather all records for a given jurisdiction and event type, both from S3 and the database. It exists as a Flask CLI command in the webapp container. It prompts you for confirmation before doing so.
+
+- Get a docker shell: `docker exec -it webapp /bin/bash`
+- `flask expunge test jail_bookings` (in this example, 'test' is the jurisdiction and 'jail_bookings' is the event type)
+
 
 ## Browser Support
 The web app is tested on the following browsers:

--- a/webapp.env
+++ b/webapp.env
@@ -7,6 +7,8 @@ SECURITY_PASSWORD_SALT=abcdefg
 BASE_DATA_PATH=s3://dsapp-criminal-justice/csh/matcher/{jurisdiction}/
 RAW_UPLOADS_PATH=s3://dsapp-criminal-justice/csh/matcher/{jurisdiction}/{event_type}/uploaded/{date}/{upload_id}
 MERGED_UPLOADS_PATH=s3://dsapp-criminal-justice/csh/matcher/{jurisdiction}/{event_type}/merged
+BASE_PATH=s3://dsapp-criminal-justice/csh/matcher/{jurisdiction}/{event_type}
+MATCH_CACHE_PATH=s3://dsapp-criminal-justice/csh/matcher/{jurisdiction}/match_cache
 
 ## Matcher connection
 MATCHER_LOCATION=matcher

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -14,3 +14,4 @@ redis
 flask-script
 colorlog
 flask-mail
+s3fs

--- a/webapp/webapp/app.py
+++ b/webapp/webapp/app.py
@@ -2,11 +2,15 @@ from flask import render_template
 from flask_security import Security, login_required, \
      SQLAlchemySessionUserDatastore
 from webapp import app
-from webapp.database import db_session
+from webapp.config import config as app_config
+from webapp.database import db_session, engine
 from webapp.models import User, Role
 from webapp.apis.upload import upload_api
 from webapp.apis.chart import chart_api
 from webapp.apis.jobs import jobs_api
+from webapp.utils import generate_matched_table_name, generate_master_table_name
+import click
+import s3fs
 
 # Setup Flask-Security
 user_datastore = SQLAlchemySessionUserDatastore(db_session,
@@ -28,7 +32,39 @@ def home(path):
 def health_check():
     return 'OK!'
 
+
 @app.teardown_appcontext
 def shutdown_session(exception=None):
     print('removing session!')
     db_session.remove()
+
+
+@app.cli.command()
+@click.argument('jurisdiction')
+@click.argument('event_type')
+def expunge(jurisdiction, event_type):
+    s3 = s3fs.S3FileSystem()
+
+    base_path = app_config['base_path'].format(jurisdiction=jurisdiction, event_type=event_type)
+    match_cache_path = app_config['match_cache_path'].format(jurisdiction=jurisdiction)
+    matched_table = generate_matched_table_name(jurisdiction, event_type)
+    master_table = generate_master_table_name(jurisdiction, event_type)
+
+    msg = 'Expunge all data for jurisdiction {} and event_type {}?'.format(jurisdiction, event_type)
+    msg += '\n\ns3 paths (recursive!): {}, {}'.format(base_path, match_cache_path)
+    msg += '\n\ndatabase tables: {}, {}'.format(matched_table, master_table)
+    msg += '\n\nYou should not do this while the system is validating or matching.'
+    msg += '\n\nRemove all this?'
+    shall = input("%s (y/N) " % msg).lower() == 'y'
+    click.echo(shall)
+    if not shall:
+        click.echo("Expunge aborted")
+
+    click.echo("Removing base path " + base_path)
+    s3.rm(base_path, recursive=True)
+    click.echo("Removing match cache path" + match_cache_path)
+    s3.rm(match_cache_path, recursive=True)
+    click.echo("Truncating matched database table " + matched_table)
+    engine.execute('truncate {}'.format(matched_table))
+    click.echo("Truncating master database table " + master_table)
+    engine.execute('truncate {}'.format(master_table))

--- a/webapp/webapp/config.py
+++ b/webapp/webapp/config.py
@@ -4,6 +4,8 @@ import os
 config = {
 	'base_data_path': os.environ['BASE_DATA_PATH'].replace('\{', '{').replace('\}', '}'),
 	'merged_uploads_path': os.environ['MERGED_UPLOADS_PATH'].replace('\{', '{').replace('\}', '}'),
+	'base_path': os.environ['BASE_PATH'].replace('\{', '{').replace('\}', '}'),
+	'match_cache_path': os.environ['MATCH_CACHE_PATH'].replace('\{', '{').replace('\}', '}'),
  	'raw_uploads_path': os.environ['RAW_UPLOADS_PATH'].replace('\{', '{').replace('\}', '}'),
     'matcher_location': os.environ['MATCHER_LOCATION'],
     'matcher_port': os.environ['MATCHER_PORT']


### PR DESCRIPTION
This Flask-CLI script expunges all data for a given jurisdiction and event type. In addition, the removal of the 'match cache' will also affect other event types as this is not scoped to a particular event type.