### PR TITLE
Make uploader usable without s3 [Resolves #320]

### DIFF
--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -6,7 +6,6 @@ alembic
 pyyaml
 psycopg2
 bcrypt
-smart_open==1.5.3
 sqlalchemy
 pandas
 rq

--- a/webapp/webapp/apis/upload.py
+++ b/webapp/webapp/apis/upload.py
@@ -6,17 +6,17 @@ from webapp.logger import logger
 from webapp.database import db_session
 from webapp.models import Upload, MergeLog
 from webapp.tasks import \
-    upload_to_s3,\
+    upload_to_storage,\
     sync_upload_metadata,\
     copy_raw_table_to_db,\
     upsert_raw_table_to_master,\
     bootstrap_master_tables,\
-    sync_merged_file_to_s3,\
+    sync_merged_file_to_storage,\
     add_missing_fields,\
     validate_file,\
     validate_header
 from webapp.users import can_upload_file, get_jurisdiction_roles
-from webapp.utils import s3_upload_path, notify_matcher, infer_delimiter, unique_upload_id
+from webapp.utils import upload_path, notify_matcher, infer_delimiter, unique_upload_id
 
 from werkzeug.utils import secure_filename
 
@@ -231,12 +231,12 @@ def validate_async(uploaded_file_name, jurisdiction, full_filename, event_type, 
         try:
             # 4. upload to s3
             upload_start_time = datetime.today()
-            upload_path = s3_upload_path(jurisdiction, event_type, upload_id)
-            upload_to_s3(upload_path, filename_with_all_fields)
+            final_upload_path = upload_path(jurisdiction, event_type, upload_id)
+            upload_to_storage(final_upload_path, filename_with_all_fields)
 
             # 5. load into raw table
             copy_raw_table_to_db(
-                upload_path,
+                final_upload_path,
                 event_type,
                 upload_id,
                 db_session.get_bind()
@@ -245,7 +245,7 @@ def validate_async(uploaded_file_name, jurisdiction, full_filename, event_type, 
             upload_complete_time = datetime.today()
             # 6. sync upload metadata to db
             sync_upload_metadata_partial(
-                s3_upload_path=upload_path,
+                s3_upload_path=final_upload_path,
                 validate_start_time=validate_start_time,
                 validate_complete_time=validate_complete_time,
                 validate_status=True,
@@ -306,7 +306,9 @@ def upload_file():
         uploaded_file = request.files[filenames[0]]
         filename = secure_filename(uploaded_file.filename)
         cwd = os.getcwd()
-        full_filename = os.path.join(cwd + '/tmp', filename)
+        tmp_dir = os.path.join(cwd, 'tmp')
+        os.makedirs(tmp_dir, exist_ok=True)
+        full_filename = os.path.join(tmp_dir, filename)
         uploaded_file.save(full_filename)
         upload_id = unique_upload_id()
         q = get_q(get_redis_connection())
@@ -355,7 +357,7 @@ def merge_file():
 
             bootstrap_master_tables(upload_log.jurisdiction_slug, db_session)
 
-            sync_merged_file_to_s3(
+            sync_merged_file_to_storage(
                 upload_log.jurisdiction_slug,
                 upload_log.event_type_slug,
                 db_session.get_bind()

--- a/webapp/webapp/storage.py
+++ b/webapp/webapp/storage.py
@@ -1,0 +1,22 @@
+import s3fs
+from urllib.parse import urlparse
+from contextlib import contextmanager
+
+
+@contextmanager
+def open_sesame(path, *args, **kwargs):
+    """Opens files either on s3 or a filesystem according to the path's scheme
+
+    Uses s3fs so boto3 is used.
+    This means mock_s3 can be used for tests, instead of the mock_s3_deprecated
+    """
+    path_parsed = urlparse(path)
+    scheme = path_parsed.scheme  # If '' of 'file' is a regular file or 's3'
+
+    if not scheme or scheme == 'file':  # Local file
+        with open(path, *args, **kwargs) as f:
+            yield f
+    elif scheme == 's3':
+        s3 = s3fs.S3FileSystem()
+        with s3.open(path, *args, **kwargs) as f:
+            yield f

--- a/webapp/webapp/utils.py
+++ b/webapp/webapp/utils.py
@@ -24,26 +24,26 @@ def unique_upload_id():
     return str(uuid4())
 
 
-def s3_upload_path(jurisdiction, event_type, upload_id):
+def upload_path(jurisdiction, event_type, upload_id):
     datestring = date.today().isoformat()
     path_template = app_config['raw_uploads_path']
 
-    full_s3_path = path_template.format(
+    full_path = path_template.format(
         event_type=event_type,
         jurisdiction=jurisdiction,
         date=datestring,
         upload_id=upload_id
     )
-    return full_s3_path
+    return full_path
 
 
 def merged_file_path(jurisdiction, event_type):
     path_template = app_config['merged_uploads_path']
-    full_s3_path = path_template.format(
+    full_path = path_template.format(
         event_type=event_type,
         jurisdiction=jurisdiction
     )
-    return full_s3_path
+    return full_path
 
 
 @contextmanager


### PR DESCRIPTION
Since much of the code was already using smart_open, the replacement here that uses boto3 has the same semantics as smart_open: an open function that switches between filesystem and s3 based on scheme.

To showcase this, there is a new endpoint test that does the while flow (uploading and merging) without mocking s3 at all to prove that it works.

- Introduce open_sesame to switch between s3 and filesystem
- Change references to 's3' in code to 'storage'
- Add bookings merge test that uses filesystem storage