### PR TITLE
Fixed failed match on timeline

### DIFF
--- a/matcher/matcher/tasks.py
+++ b/matcher/matcher/tasks.py
@@ -18,7 +18,7 @@ from matcher.logger import logger
 
 
 from redis import Redis
-from rq import Queue 
+from rq import Queue
 redis_connection = Redis(host='redis', port=6379)
 q = Queue('webapp', connection=redis_connection)
 
@@ -96,18 +96,10 @@ def do_match(
         logger.info('Finished')
         match_end_time = datetime.datetime.now()
         match_runtime =  match_end_time - metadata['match_job_start_time']
-        
+
         match_successful = True
         status_message = 'new matches are available. Yipee!'
 
-    except Exception as e:
-        logger.error(f'Matcher failed with message "{str(e)}"')
-        match_end_time = datetime.datetime.now()
-        match_run_time = match_end_time - metadata['match_job_start_time']
-        match_successful = False
-        status_message = 'matching failed. SAD!'
-
-    finally:
         if notify_webapp:
             job = q.enqueue_call(
                 func='webapp.match_finished',
@@ -124,5 +116,29 @@ def do_match(
             )
             logger.info(f'Notified the webapp that {status_message}')
 
-        logger.info('All done!!')
+    except Exception as e:
+        match_end_time = datetime.datetime.now()
+        match_run_time = match_end_time - metadata['match_job_start_time']
+        match_successful = False
+        status_message = 'matching failed. SAD!'
+        if notify_webapp:
+            logger.error(f'Matcher failed with message "{str(e)}"')
+            logger.error("Notifying the webapp")
+            job = q.enqueue_call(
+                func='webapp.match_finished',
+                args=(
+                    None,
+                    metadata['match_job_id'],
+                    metadata['match_job_start_time'],
+                    None,
+                    match_successful,
+                    None,
+                    upload_id
+                ),
+                result_ttl=5000
+            )
+            logger.info(f'Notified the webapp that {status_message}')
+
+    finally:
+        logger.info('Matcher done!!')
 

--- a/webapp/frontend/components/timeline.js
+++ b/webapp/frontend/components/timeline.js
@@ -75,7 +75,7 @@ class ActionTimeLine extends React.Component {
       <TimelineEvent
           title={"Completed Task #" + item.index + " - " + item.validate_start_time}
           icon={<i className="material-icons md-18">cloud_upload</i>}
-          iconColor={(item['validate_status'] || item['upload_status']) ? "#43C6DB" : "#ff7456" }
+          iconColor={(item['validate_status'] && item['upload_status'] && item['match_status']) ? "#43C6DB" : "#ff7456" }
           key={idx}>
 
         {keys(lookup).map((k) => {

--- a/webapp/webapp/tasks.py
+++ b/webapp/webapp/tasks.py
@@ -306,7 +306,6 @@ def write_upload_log(
 
 
 def write_match_log(db_session, match_job_id, upload_id, match_start_at, match_complete_at, match_status, match_runtime):
-    logger.info("Start writing to match log")
     db_object = MatchLog(
         id=match_job_id,
         upload_id=upload_id,

--- a/webapp/webapp/tasks.py
+++ b/webapp/webapp/tasks.py
@@ -306,6 +306,7 @@ def write_upload_log(
 
 
 def write_match_log(db_session, match_job_id, upload_id, match_start_at, match_complete_at, match_status, match_runtime):
+    logger.info("Start writing to match log")
     db_object = MatchLog(
         id=match_job_id,
         upload_id=upload_id,
@@ -341,7 +342,7 @@ def write_matches_to_db(db_engine, event_type, jurisdiction, matches_filehandle)
     logging.info(create)
     db_engine.execute(create)
 
-    # 2. copy data from filehandle to 
+    # 2. copy data from filehandle to
     conn = db_engine.raw_connection()
     cursor = conn.cursor()
     pk = ','.join([col for col in primary_key])
@@ -409,3 +410,6 @@ def match_finished(
                 )
     except Exception as e:
         logger.error('Error encountered during match_finished: %s', str(e))
+
+    finally:
+        logger.info('All done!')


### PR DESCRIPTION
The reason why the timeline didn't catch the failure in matcher is because when the failure appears in the early stage, it will break out of the try statement and result in some of the arguments that are passed into queue being referenced before assigned. Therefore, the queue won't be executed, the metadata won't be written into the match log and then the whole block will disappear.

It is fixed now. When the `match_status` is false, the `match_complete_timestamp` is the time when it fails.