### PR TITLE
 Database retry functionality and merge error visibility [Resolves #346] 

### DIFF
--- a/webapp/frontend/actions/index.js
+++ b/webapp/frontend/actions/index.js
@@ -189,12 +189,12 @@ export function setAppState(stateKey, value) {
 
 export function confirmUpload(uploadId) {
   return function(dispatch) {
+    dispatch(setAppState('mergeResults.status', ''))
     dispatch(setAppState('mergingIsLoading', true))
     return fetch('api/upload/merge_file?uploadId='+uploadId, { method: 'POST', credentials: 'include'})
       .then((resp) => {
         if(!resp.ok) {
-          dispatch(errorMessage('Error merging data. Please try again later.'))
-          dispatch(setAppState('mergingIsLoading', false))
+          return {'status': 'error'}
         }
         return resp.json()
       })

--- a/webapp/frontend/components/upload.js
+++ b/webapp/frontend/components/upload.js
@@ -19,7 +19,7 @@ function mapStateToStep(state) {
     return 2
   } else if (state.app.validationResponse.status === '' || state.app.validationResponse.status === 'invalid' || state.app.validationResponse.status === 'error') {
     return 1
-  } else if (state.app.mergeResults.totalUniqueRows !== '') {
+  } else if (state.app.mergeResults.status === 'success') {
     return 4
   } else if (state.app.validationResponse.status === 'valid') {
     return 3
@@ -29,7 +29,8 @@ function mapStateToStep(state) {
 function mapStateToProps(state) {
   return {
     uploadProblem: ['invalid', 'error'].includes(state.app.validationResponse.status ),
-    step: mapStateToStep(state)
+    step: mapStateToStep(state),
+    mergeProblem: state.app.mergeResults.status === 'error',
   }
 }
 
@@ -97,7 +98,10 @@ class UploadPage extends React.Component {
               >Validate File</StepLabel>
             </Step>
             <Step>
-              <StepLabel>Confirm Upload</StepLabel>
+              <StepLabel
+                icon={this.props.mergeProblem ? <WarningIcon color={red500} /> : 4}
+                style={this.props.mergeProblem ? { color: red500} : {}}
+              >Confirm Upload</StepLabel>
             </Step>
             <Step>
               <StepLabel>Done!</StepLabel>

--- a/webapp/frontend/components/upload/confirm-data.js
+++ b/webapp/frontend/components/upload/confirm-data.js
@@ -3,6 +3,7 @@ import RaisedButton from 'material-ui/RaisedButton'
 import Reactable from 'reactable'
 import { pickFile, resetEventType, resetUploadResponse, confirmUpload } from '../../actions'
 import { connect } from 'react-redux'
+import {red500} from 'material-ui/styles/colors'
 
 function mapStateToProps(state) {
   return {
@@ -11,7 +12,8 @@ function mapStateToProps(state) {
     fieldOrder: state.app.uploadResponse.fieldOrder,
     numRows: state.app.uploadResponse.rowCount,
     uploadId: state.app.uploadResponse.uploadId,
-    mergingIsLoading: state.app.mergingIsLoading
+    mergingIsLoading: state.app.mergingIsLoading,
+    mergeProblem: state.app.mergeResults.status === 'error',
   }
 }
 
@@ -33,13 +35,15 @@ function mapDispatchToProps(dispatch) {
 
 const styles = {
   button: { margin: 12, },
-  step: { marginLeft: 75 }
+  step: { marginLeft: 75 },
+  error: { color: red500 }
 }
 
 class ConfirmData extends React.Component {
   renderButtons() {
     return (
       <div>
+        <p style={this.props.mergeProblem ? error : {}}>{this.props.mergeProblem ? 'There was a problem confirming the upload. Please try again.' : ''}</p>
         <RaisedButton
           onMouseUp={this.props.confirm(this.props.uploadId)}
           disabled={this.props.mergingIsLoading}

--- a/webapp/frontend/reducers/index.js
+++ b/webapp/frontend/reducers/index.js
@@ -72,6 +72,7 @@ const initialState = {
     mergeResults: {
       totalUniqueRows: '',
       newUniqueRows: '',
+      status: '',
     },
     selectedJurisdiction: {
       name: '',
@@ -187,7 +188,8 @@ const app = createReducer(initialState, {
     const newState = Object.assign({}, state, {
       mergeResults: {
         newUniqueRows: payload.new_unique_rows,
-        totalUniqueRows: payload.total_unique_rows
+        totalUniqueRows: payload.total_unique_rows,
+        status: payload.status
       }
     })
     return newState

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -14,3 +14,4 @@ flask-script
 colorlog
 flask-mail
 s3fs
+retrying

--- a/webapp/webapp/apis/upload.py
+++ b/webapp/webapp/apis/upload.py
@@ -372,7 +372,7 @@ def merge_file():
                 return make_response(jsonify(status='error'), 500)
             db_session.commit()
             return jsonify(
-                status='valid',
+                status='success',
                 new_unique_rows=merge_log.new_unique_rows,
                 total_unique_rows=merge_log.total_unique_rows
             )

--- a/webapp/webapp/tests/test_endpoints.py
+++ b/webapp/webapp/tests/test_endpoints.py
@@ -232,7 +232,7 @@ class MergeFileTestCase(unittest.TestCase):
             # call the merge endpoint
             response = app.post('/api/upload/merge_file?uploadId={}'.format(upload_id))
             response_data = json.loads(response.get_data().decode('utf-8'))
-            assert response_data['status'] == 'valid'
+            assert response_data['status'] == 'success'
             # make sure that there is a new merged file on s3
             expected_s3_path = 's3://test-bucket/boone/hmis_service_stays/merged'
             with open_sesame(expected_s3_path, 'rb') as expected_s3_file:
@@ -264,7 +264,7 @@ class MergeFileTestCase(unittest.TestCase):
             # now merge the right one, the db should not be in a weird state
             response = app.post('/api/upload/merge_file?uploadId={}'.format(upload_id))
             response_data = json.loads(response.get_data().decode('utf-8'))
-            assert response_data['status'] == 'valid'
+            assert response_data['status'] == 'success'
 
 
 class MergeBookingsFileTestCase(unittest.TestCase):
@@ -302,7 +302,7 @@ class MergeBookingsFileTestCase(unittest.TestCase):
             # call the merge endpoint
             response = app.post('/api/upload/merge_file?uploadId={}'.format(upload_id))
             response_data = json.loads(response.get_data().decode('utf-8'))
-            assert response_data['status'] == 'valid'
+            assert response_data['status'] == 'success'
             # make sure that there is a new merged file on s3
             expected_s3_path = 's3://test-bucket/boone/jail_bookings/merged'
             with open_sesame(expected_s3_path, 'rb') as expected_s3_file:
@@ -330,7 +330,7 @@ class MergeBookingsFileTestCase(unittest.TestCase):
                     # call the merge endpoint
                     response = app.post('/api/upload/merge_file?uploadId={}'.format(upload_id))
                     response_data = json.loads(response.get_data().decode('utf-8'))
-                    assert response_data['status'] == 'valid'
+                    assert response_data['status'] == 'success'
                     # make sure that there is a new merged file on the FS
                     expected_path = os.path.join(temp_dir, 'boone-jail_bookings-merged')
                     with open(expected_path, 'rb') as expected_file:


### PR DESCRIPTION
There was a twofold problem in the beta with regards to an unexpected transient database error in the data merge step.

1. The Python webapp should retry transient database errors, but cut it off quickly because the webapp is waiting, and we don't want to get to the one minute request limit.

- Add retrying Python module to webapp and introduce db_retry decorator for short-term retrying of all database tasks

2. The frontend should show an error message if the merge has an error and tell the user to retry.

- Modify upload flow to look for a mergeResults.status key and show output to the user if something went wrong
- Modify upload API to return 'success' instead of 'valid' as a semantic change: 'valid' implies that the user had any control over the input (like in validation), but in this case we are just hoping that the backend did the right thing.