### PR TITLE
Docs skeleton [Resolves #360]

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: Matching Tool
+docs_dir: sources
+theme: material
+pages:
+    - {Home: index.md}
+    - For Users:
+        - {Using the Tool: users/using.md}
+        - {Schemas: users/schemas.md}
+    - For Administrators:
+        - {Installing: admin/install.md}
+        - {Troubleshooting: admin/troubleshooting.md}
+        - {Updating: admin/updating.md}
+    - For Developers:
+        - {Creating a new Schema: dev/schemas.md}
+        - {Modifying the Webapp: dev/webapp.md}
+        - {Modifying the Matching Service : dev/matching.md}

--- a/docs/sources/admin/install.md
+++ b/docs/sources/admin/install.md
@@ -1,0 +1,49 @@
+# Installing the matching-tool
+
+## Requirements
+
+- Docker and Docker-Compose; this is not strictly needed, but the only way to install that DSaPP is supporting and documenting.
+- AWS S3; For development and testing purposes, [Moto standalone S3 server](#s3-credentials) can work, but it is not meant for production as the stored S3 data will disappear as soon as the process ends.
+
+
+## Deploy with Docker
+
+### Production
+
+1. Set up a Postgres server. [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.PostgreSQL.html) is recommended, though you may set up and administrate your own if desired.
+2. Set up a machine/instance that will run the matching tool. Log into this machine; the rest of the steps assume that you are on the machine.
+3. Clone the git repository: `git clone https://github.com/dssg/matching-tool.git` (this will require git to be installed if the machine didn't come with it)
+4. `cd matching-tool` to change into the repository root directory.
+5. Run the docker install script. Log out and back in when it completes. `./scripts/1_install_docker`
+6. Run the database prepare script. This will create a Postgres database and populate the .env file needed to run the docker infrastructure. It requires the following arguments:
+	- The address of the running Postgres server from step 1
+	- The port of the running Postgres server from step 1
+	- The name and password of a superuser on the Postgres server from step 1 that can create databases. If you are using Amazon RDS as directed, this user is created as part of the Postgres launch step.
+	- The name of a new database to create for the webapp
+
+	The script is run like this: `./scripts/2_prepare_db PGSERVER PGPORT SUPER_USER NEW_DATABASE`
+	Example: `./scripts/2_prepare_db mypostgres.county.gov 5432 postgresadmin matching_tool`
+	In addition to the Postgres database, this will prepopulate a .env file of environment variables that the Docker infrastructure will use.
+7. Add AWS environment variables for S3 access:
+	- Open up your .env file and modify the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables with your values. Visit [Managing Access Keys for your AWS Account](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) if you don't have an access key yet.
+	- Open up the webapp.env file and modify all the instances of `your-bucket` to an S3 bucket you want to use to store data.
+8. (optional) If you would like the web application to be able to send mail (e.g. for the reset password form), also modify the `MAIL_SERVER`, `MAIL_USERNAME`, `MAIL_PASSWORD`, and `MAIL_DEFAULT_SENDER` variables. Depending on your mailing setup, `MAIL_PORT` (default: 465), `MAIL_USE_SSL` (default: True), `MAIL_USE_TLS` (default: False) can be overridden. If you don't set any mail environment variables, the reset password form will not work, but the rest of the app will.
+9. (optional) Perform Redis tweaks. This is tested on Ubuntu. For other OSes, the method for making these changes may be different. Also, the need these changes may not be there for all OSes; Ubuntu's default configuration is not ideal for Redis within docker. If you're not sure, when you start up docker-compose in step 4, if Redis throws any warnings, listen to them. It will run without these, but without doing this you may increase the chances for weird system errors.
+	- Disable Transparent HugePage in the current session: `echo never > /sys/kernel/mm/transparent_hugepage/enabled`
+	- Disable Transparent HugePage for future reboots: modify the /etc/rc.local file as root
+	- Enable overcommitt memory: `sudo sysctl vm.overcommit_memory=1`
+10. Initialize the webapp database and create a web user with the `create_user` script. The script requires the following:
+	- A short name for your jurisdiction (e.g. 'Cook'). Don't include spaces as it will confuse the script. This is just the name that shows up at the top of the webapp.
+	- An email address for the web app login user
+	- A password for the web app login user
+	- A list of 'event types' that the user will have access to upload (e.g. `hmis_service_stays`, `jail_bookings`). If you want to see all the available event types, run the script without any to see the full list (e.g. `./scripts/3_create_user`)
+	Example: `./scripts/3_create_user mycounty thcrockett@uchicago.edu password hmis_service_stays jail_bookings`
+11. At this point, the web app should be running at port 80 on the machine.
+
+### Development
+1. Set up needed environment variables.
+ - S3: Ideally, this should be run on an EC2 instance with an IAM role capable of accessing S3. You can totally ignore any S3 environment variables in that case. If not, ensure that you have values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` set globally, or any other way that [boto3 can read](http://boto3.readthedocs.io/en/latest/guide/configuration.html).
+ - Flask, Postgres: These are set up by the development docker-compose, so no need to do anything here.
+2. Install [Docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/)
+3. Bring up the docker containers using our development docker-compose: `docker-compose up`
+4. Initialize the database and users. You can use this script to get set up easily, including a user 'testuser@example.com' with password 'password', that you can use to log in: `sh scripts/create_test_users_docker.sh`

--- a/docs/sources/admin/troubleshooting.md
+++ b/docs/sources/admin/troubleshooting.md
@@ -1,0 +1,1 @@
+# For Administrators: Troubleshooting

--- a/docs/sources/admin/updating.md
+++ b/docs/sources/admin/updating.md
@@ -1,0 +1,1 @@
+# Updating the Tool

--- a/docs/sources/dev/matching.md
+++ b/docs/sources/dev/matching.md
@@ -1,0 +1,1 @@
+# Updating the Matching Service

--- a/docs/sources/dev/schemas.md
+++ b/docs/sources/dev/schemas.md
@@ -1,0 +1,1 @@
+# Creating a new Schema

--- a/docs/sources/dev/webapp.md
+++ b/docs/sources/dev/webapp.md
@@ -1,0 +1,1 @@
+# Modifying the Webapp

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -1,0 +1,3 @@
+# Matching Tool
+
+Let's write some intro text about the matching tool here

--- a/docs/sources/users/schemas.md
+++ b/docs/sources/users/schemas.md
@@ -1,0 +1,1 @@
+# Schemas

--- a/docs/sources/users/using.md
+++ b/docs/sources/users/using.md
@@ -1,0 +1,1 @@
+# User Guide

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-material


### PR DESCRIPTION
Adding a skeleton along with the installation doc.

Run docs by installing from requirements_docs.txt (I created a virtualenv for it), changing to docs directory,  running 'mkdocs serve' and going to the address it points you to.