### PR TITLE
Only compare initial of middle name and last letter of sex

### DIFF
--- a/matcher/matcher_config.yaml
+++ b/matcher/matcher_config.yaml
@@ -44,21 +44,8 @@ contrasts:
                method: jarowinkler
     middle_name:
         - method: compare_exact 
-        - method: compare_exact 
           args:
-               n_chars: 5
-        - method: compare_exact 
-          args:
-               n_chars: -5
-        - method: compare_exact 
-          args:
-               n_chars: 3
-        - method: compare_exact 
-          args:
-               n_chars: -3
-        - method: compare_string_distance
-          args:
-               method: jarowinkler
+               n_chars: 1
     last_name:
         - method: compare_exact 
         - method: compare_exact 
@@ -107,7 +94,6 @@ contrasts:
     ethnicity:
         - method: compare_exact
     sex:
-        - method: compare_exact
         - method: compare_exact
           args:
                n_chars: -1

--- a/matcher/matcher_config_for_reduced_dataset.yaml
+++ b/matcher/matcher_config_for_reduced_dataset.yaml
@@ -43,21 +43,8 @@ contrasts:
                method: jarowinkler
     middle_name:
         - method: compare_exact 
-        - method: compare_exact 
           args:
-               n_chars: 5
-        - method: compare_exact 
-          args:
-               n_chars: -5
-        - method: compare_exact 
-          args:
-               n_chars: 3
-        - method: compare_exact 
-          args:
-               n_chars: -3
-        - method: compare_string_distance
-          args:
-               method: jarowinkler
+               n_chars: 1
     last_name:
         - method: compare_exact 
         - method: compare_exact 


### PR DESCRIPTION
This PR updates the matcher configs to hopefully improve matches. For both the recommended default config and the reduced config, it changes the middle name comparisons to only consider the first letter. For the default config, it also eliminates the exact match on sex in favor of only comparing the last letter.