### PR TITLE
Improve installation documentation

### DIFF
--- a/docs/sources/admin/install.md
+++ b/docs/sources/admin/install.md
@@ -3,18 +3,21 @@
 ## Requirements
 
 - Docker and Docker-Compose; this is not strictly needed, but the only way to install that DSaPP is supporting and documenting.
+- We strongly recommend running on a Linux machine and particularly recommend Ubuntu as some of the installation convenience scripts do assume Ubuntu. If this is being run on an Amazon Web Services instance, a well-tested choice is community AMI id `ami-79873901`. If being run locally, run Ubuntu Xenial 16.04 Server Edition.
 - AWS S3 by default, or enough space on the local filesystem to handle uploaded files.
 
 
 ## Deploy with Docker
 
+If you are deploying the matching tool with the goal of having users actively use it to upload real data, and you want that data to persist, follow the [Production](#production) section. If you just want to try out the tool with fake data and do active development on it, follow the [Development](#development) section.
+
 ### Production
 
 1. Set up a Postgres server. [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.PostgreSQL.html) is recommended, though you may set up and administrate your own if desired.
-2. Set up a machine/instance that will run the matching tool. Log into this machine; the rest of the steps assume that you are on the machine.
+2. Set up a machine/instance that will run the matching tool (see [requirements](#requirements) section for recommendations). Log into this machine; the rest of the steps assume that you are on the machine.
 3. Clone the git repository: `git clone https://github.com/dssg/matching-tool.git` (this will require git to be installed if the machine didn't come with it)
 4. `cd matching-tool` to change into the repository root directory.
-5. Run the docker install script. Log out and back in when it completes. `./scripts/1_install_docker`
+5. Install docker and docker-compose. If you are on an Ubuntu machine, you can use the included executable script `./scripts/1_install_docker` as a convenience for doing so. Otherwise, refer to the [Docker](https://docs.docker.com/install) and [Docker Compose](https://docs.docker.com/compose/install/) documentation. If running the included install script, log out and back in when it completes as it will add your user to the 'docker' group, and that change requires a new login to take effect.
 6. Run the database prepare script. This will create a Postgres database and populate the .env file needed to run the docker infrastructure. It requires the following arguments:
 	- The address of the running Postgres server from step 1
 	- The port of the running Postgres server from step 1
@@ -34,22 +37,28 @@
 9. (optional) Perform Redis tweaks. This is tested on Ubuntu. For other OSes, the method for making these changes may be different. Also, the need these changes may not be there for all OSes; Ubuntu's default configuration is not ideal for Redis within docker. If you're not sure, when you start up docker-compose in step 4, if Redis throws any warnings, listen to them. It will run without these, but without doing this you may increase the chances for weird system errors.
 	- Disable Transparent HugePage in the current session: `echo never > /sys/kernel/mm/transparent_hugepage/enabled`
 	- Disable Transparent HugePage for future reboots: modify the /etc/rc.local file as root
-	- Enable overcommitt memory: `sudo sysctl vm.overcommit_memory=1`
+	- Enable overcommit memory: `sudo sysctl vm.overcommit_memory=1`
 10. Initialize the webapp database and create a web user with the `create_user` script. The script requires the following:
 	- A short name for your jurisdiction (e.g. 'Cook'). Don't include spaces as it will confuse the script. This is just the name that shows up at the top of the webapp.
 	- An email address for the web app login user
 	- A password for the web app login user
 	- A list of 'event types' that the user will have access to upload (e.g. `hmis_service_stays`, `jail_bookings`). If you want to see all the available event types, run the script without any to see the full list (e.g. `./scripts/3_create_user`)
-	Example: `./scripts/3_create_user mycounty thcrockett@uchicago.edu password hmis_service_stays jail_bookings`
+	- Example: `./scripts/3_create_user mycounty thcrockett@uchicago.edu password hmis_service_stays jail_bookings`
 11. At this point, the web app should be running at port 80 on the machine.
 
 ### Development
-1. Set up needed environment variables.
- - S3: Ideally, this should be run on an EC2 instance with an IAM role capable of accessing S3. You can totally ignore any S3 environment variables in that case. If not, ensure that you have values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` set globally, or any other way that [boto3 can read](http://boto3.readthedocs.io/en/latest/guide/configuration.html).
- - Flask, Postgres: These are set up by the development docker-compose, so no need to do anything here.
-2. Install [Docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/)
-3. Bring up the docker containers using our development docker-compose: `docker-compose up`
-4. Initialize the database and users. You can use this script to get set up easily, including a user 'testuser@example.com' with password 'password', that you can use to log in: `sh scripts/create_test_users_docker.sh`
+
+1. Clone the git repository: `git clone https://github.com/dssg/matching-tool.git` (this will require git to be installed if the machine didn't come with it)
+2. `cd matching-tool` to change into the repository root directory.
+3. Install docker and docker-compose. If you are on an Ubuntu machine, you can use the included executable script `./scripts/1_install_docker` script as a convenience for doing so. Otherwise, refer to the [Docker](https://docs.docker.com/install) and [Docker Compose](https://docs.docker.com/compose/install/) documentation. If running the included install script, log out and back in when it completes as it will add your user to the 'docker' group, and that change requires a new login to take effect.
+4. Set up storage.
+    1. Option 1 (S3):
+	    - Open up your .env file and modify the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables with your values. Visit [Managing Access Keys for your AWS Account](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) if you don't have an access key yet.
+	    - Open up the webapp.env file and modify all the instances of `your-bucket` to an S3 bucket you want to use to store data.
+    2. Option 2 (Filesystem): [configuration changes](install.md#using-the-filesystem)
+5. Bring up the docker containers using our development docker-compose: `docker-compose -f docker-compose-dev.yml up`
+6. Initialize the database and users. You can use [this script](https://github.com/dssg/matching-tool/blob/master/scripts/development/create_test_users_docker.sh) to get set up easily, including a user `testuser@example.com` with password `password`, that you can use to log in: `sh scripts/development/create_test_users_docker.sh`
+7. At this point, the web app should be running at port 80 on the machine.
 
 
 ### Using the Filesystem
@@ -60,4 +69,4 @@ For instance: `mkdir ./shared-volume; chmod 777 ./shared-volume` would then allo
 
 `- ./shared-volume:/shared-volume`
 
-With this in place, each container will have a `/shared-volume` directory that can be used as a base path in `webapp.env`
+With this in place, each container will have a `/shared-volume` directory that can be used as a root directory for the various `_PATH` variables in `webapp.env`


### PR DESCRIPTION
- Separate out full user creation example into own bullet point
[Resolves #388]
- Beef up development section to make it clear when to use it, and with
more relevant details. There were several old parts of it that needed fixing, and now it mirrors the Production section more closely. [Resolves #389]