### PR TITLE
Sort results with NULLs last [Resolves #328]:

### DIFF
--- a/docs/sources/users/using.md
+++ b/docs/sources/users/using.md
@@ -87,7 +87,9 @@ After you have confirmed your upload, the next screen will show the number of to
 
 The Results page provides a summary of the results based on the data uploaded and matched from the County’s jail bookings and HMIS stays. 
 
-Each of the data fields can be clicked on to sort the data based on the field specified in either ascending or descending order. The Results page also provides the total number of records, the number of jail booking records, the number of HMIS stay records, and the number of records and  percent of HMIS and Jail booking records found in both datasets. The tool also provides the data field information by clicking on the question mark icon at the top of the page (under Upload Data).
+The Results page also provides the total number of records, the number of jail booking records, the number of HMIS stay records, and the number of records and  percent of HMIS and Jail booking records found in both datasets. The tool also provides the data field information by clicking on the question mark icon at the top of the page (under Upload Data).
+
+Each of the data fields can be clicked on to sort the data based on the field specified in either ascending or descending order, with null or empty values always appearing last. This means that, for example, if you sort by last jail booking date, someone who has never been in jail will always appear at the bottom of the list, regardless of whether you sort with most recent bookings first or least recent bookings first. To see people with no jail contacts, click on the Homeless only portion of the Venn diagram.
 
 **Figure 10: Results Page Overview**
 

--- a/webapp/backend/apis/query.py
+++ b/webapp/backend/apis/query.py
@@ -244,7 +244,7 @@ def get_records_by_time(
     rows_to_show = [dict(row) for row in db.engine.execute("""
         {}
         where {}
-        order by {} {}
+        order by {} {} nulls last
         limit {} offset %(offset)s""".format(
             base_query,
             status_filter,


### PR DESCRIPTION
This commit changes how results are sorted on the results page so that
regardless of what sort order a user requests for a given column, NULL
values always appear at the end of the list. It also updates the
documentation to specify this and to view NULLs for service-specific
columns.