### PR TITLE
Remove quotes from the example .env file

### DIFF
--- a/_env
+++ b/_env
@@ -10,14 +10,14 @@ SECRET_KEY=dev
 SECURITY_PASSWORD_SALT=abcdefg
 
 # AWS access (for S3)
-AWS_ACCESS_KEY_ID=""
-AWS_SECRET_ACCESS_KEY=""
+AWS_ACCESS_KEY_ID=example
+AWS_SECRET_ACCESS_KEY=example
 
 # Mail configuration (optional, only needed for reset password functionality in webapp)
-MAIL_SERVER=""
+MAIL_SERVER=example
 MAIL_PORT=625
 MAIL_USE_SSL=True
 MAIL_USE_TLS=False
-MAIL_USERNAME=""
-MAIL_PASSWORD=""
-MAIL_DEFAULT_SENDER=""
+MAIL_USERNAME=example
+MAIL_PASSWORD=example
+MAIL_DEFAULT_SENDER=example

--- a/_env
+++ b/_env
@@ -10,14 +10,14 @@ SECRET_KEY=dev
 SECURITY_PASSWORD_SALT=abcdefg
 
 # AWS access (for S3)
-AWS_ACCESS_KEY_ID=example
-AWS_SECRET_ACCESS_KEY=example
+AWS_ACCESS_KEY_ID=EXAMPLEKEY
+AWS_SECRET_ACCESS_KEY=EXAMPLE/KEY
 
 # Mail configuration (optional, only needed for reset password functionality in webapp)
-MAIL_SERVER=example
+MAIL_SERVER=mail.example.com
 MAIL_PORT=625
 MAIL_USE_SSL=True
 MAIL_USE_TLS=False
-MAIL_USERNAME=example
-MAIL_PASSWORD=example
-MAIL_DEFAULT_SENDER=example
+MAIL_USERNAME=example_username
+MAIL_PASSWORD=example_password
+MAIL_DEFAULT_SENDER=admin@example.com


### PR DESCRIPTION
In the example .env file, where no default or example string is given for an environment variable, a pair of empty quotes is given. This may lead users to insert the replacement string _inside_ the quotes. This commit suggests replacing those quotes with the word _example_ to potentially avoid this issue.