### PR TITLE
Add json-loader to webpack build [Resolves #397]

### DIFF
--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -32,6 +32,7 @@
     "d3": "3.5.17",
     "html2canvas": "^1.0.0-alpha.9",
     "immutability-helper": "^2.4.0",
+    "json-loader": "^0.5.7",
     "material-ui": "^0.18.7",
     "material-ui-datatables": "^0.18.2",
     "moment": "^2.20.1",

--- a/webapp/frontend/webpack.config.prod.js
+++ b/webapp/frontend/webpack.config.prod.js
@@ -27,6 +27,11 @@ module.exports = {
         }
       },
       {
+        test: /\.json$/,
+        include: /node_modules/,
+        loader: 'json-loader'
+      },
+      {
         test: /\.css$/i,
         loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
       },


### PR DESCRIPTION
Adds json-loader to webpack. This is needed as of recently due to, we
think, a recent dependency update.

On instances deployed with Docker, this change will require a rebuild of
the Docker image.

- Add json-loader to package.json
- Add json-loader to webpack build