### PR TITLE
Fix expunge script [Resolves #398]

### DIFF
--- a/webapp/backend/app.py
+++ b/webapp/backend/app.py
@@ -2,6 +2,7 @@ from flask import render_template
 from flask_security import Security, login_required, \
      SQLAlchemySessionUserDatastore
 from backend import app
+from backend.storage import remove_recursively
 from backend.config import config as app_config
 from backend.database import db_session, engine
 from backend.models import User, Role
@@ -10,7 +11,6 @@ from backend.apis.chart import chart_api
 from backend.apis.jobs import jobs_api
 from backend.utils import generate_master_table_name
 import click
-import s3fs
 
 # Setup Flask-Security
 user_datastore = SQLAlchemySessionUserDatastore(db_session,
@@ -43,14 +43,12 @@ def shutdown_session(exception=None):
 @click.argument('event_type')
 def expunge(jurisdiction, event_type):
     """Expunges all data for a given jurisdiction and event type"""
-    s3 = s3fs.S3FileSystem()
-
     base_path = app_config['base_path'].format(jurisdiction=jurisdiction, event_type=event_type)
     match_cache_path = app_config['match_cache_path'].format(jurisdiction=jurisdiction)
     master_table = generate_master_table_name(jurisdiction, event_type)
 
     msg = 'Expunge all data for jurisdiction {} and event_type {}?'.format(jurisdiction, event_type)
-    msg += '\n\ns3 paths (recursive!): {}, {}'.format(base_path, match_cache_path)
+    msg += '\n\nstorage paths (recursive!): {}, {}'.format(base_path, match_cache_path)
     msg += '\n\ndatabase tables: {}'.format(master_table)
     msg += '\n\nYou should not do this while the system is validating or matching.'
     msg += '\n\nRemove all this?'
@@ -59,9 +57,9 @@ def expunge(jurisdiction, event_type):
     if not shall:
         click.echo("Expunge aborted")
 
-    click.echo("Removing base path " + base_path)
-    s3.rm(base_path, recursive=True)
-    click.echo("Removing match cache path" + match_cache_path)
-    s3.rm(match_cache_path, recursive=True)
     click.echo("Truncating master database table " + master_table)
     engine.execute('truncate {}'.format(master_table))
+    click.echo("Removing base path " + base_path)
+    remove_recursively(base_path)
+    click.echo("Removing match cache path" + match_cache_path)
+    remove_recursively(match_cache_path)


### PR DESCRIPTION
The expunge script was not resilient to a directory being absent, and it
wasn't implemented at all for filesystem.

- Create remove_recursively in backend.storage that works for both S3
and FS and is fine if the path doesn't exist. Add unit test
- Change expunge script to use remove_recursively